### PR TITLE
Allow install scripts in pnpm install

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+packages:
+  - './'
+onlyBuiltDependencies:
+  - '@swc/core'
+  - cypress
+  - esbuild


### PR DESCRIPTION
These dependencies are using install scripts:

- cypress
- esbuild
- @swc/core
