### PR TITLE
Add dependency age policy settings

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,9 @@
 packages:
   - './'
+# Source of truth:
+# https://github.com/kitsuyui/kitsuyui/wiki/Official-Information-for-Dependency-Update-Policies
+# 3 days = 4320 minutes
+minimumReleaseAge: 4320
 onlyBuiltDependencies:
   - '@swc/core'
   - cypress


### PR DESCRIPTION
## Summary
- add `minimumReleaseAge: 4320` to the pnpm workspace settings
- add inline comments that point to the wiki page used as the source of truth

## Why
- this introduces a 3 day package age policy for pnpm installs
- the rationale and official references are maintained in the shared wiki document

## Reference
- https://github.com/kitsuyui/kitsuyui/wiki/Official-Information-for-Dependency-Update-Policies

## Validation
- YAML syntax check
