### PR TITLE
fix: ignore nyc output in Biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -38,6 +38,7 @@
       "**",
       "!**/out",
       "!**/node_modules",
+      "!**/.nyc_output",
       "!**/typedocs",
       "!**/build",
       "!**/pnpm-lock.yaml"


### PR DESCRIPTION
## Summary
- exclude the local `.nyc_output` directory from Biome checks
- keep generated coverage artifacts from polluting the lint baseline

## Testing
- pnpm lint
- pnpm build
