### PR TITLE
Use Vite preview for start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite dev --port 3000",
     "build": "vite build",
-    "start": "vite start --port 3000",
+    "start": "vite preview --port 3000",
     "lint": "biome check .",
     "test": "cypress run",
     "test:coverage": "cypress run",


### PR DESCRIPTION
## Summary
- Change the start script from `vite start` to the explicit `vite preview` command.
- Keep the existing port 3000 behavior.

## Verification
- bun install
- bun run build
- bun run start -- --help
- bun run start, then curl http://localhost:3000
- git diff --check
