### PR TITLE
Make test workflow failures blocking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,12 +5,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    continue-on-error: true
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: [20.x, 22.x, 24.x]
-
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

- Remove `continue-on-error` from the pull request test workflow.
- Remove the unused Node version matrix from the Bun-based test job.

## Why

The test workflow should fail pull requests when lint, build, or E2E tests fail. The previous Node matrix did not affect any setup step, so each matrix entry ran the same Bun-based job while remaining non-blocking.

## Validation

- `actionlint .github/workflows/test.yml`
- `bun install --frozen-lockfile`
- `bun run lint`
- `bun run build`
- `bun x cypress install`
- E2E workflow command with `vite preview` and `bun run test`
