### PR TITLE
Make happy workflow failures blocking

### DIFF
--- a/.github/workflows/happy.yml
+++ b/.github/workflows/happy.yml
@@ -11,7 +11,6 @@ jobs:
   happy:
     runs-on: ubuntu-latest
     name: happy
-    continue-on-error: true
     steps:
       - uses: kitsuyui/happy-commit@v0.9
         with:


### PR DESCRIPTION
## Summary

- Remove `continue-on-error` from the happy-commit workflow so action failures block the pull request check.
- Keep the existing workflow trigger, permissions, and action inputs unchanged.

## Validation

- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/happy.yml"); puts "yaml ok"'\n- actionlint .github/workflows/happy.yml\n- bun install --frozen-lockfile\n- bun run lint\n- bun run build\n- bun x cypress install\n- bun run test with local `vite preview` on 127.0.0.1:3000\n\nNote: the local build emits the existing Vite React SWC deprecation warning, and Cypress emits existing `allowCypressEnv` / coverage instrumentation warnings, but the commands exit successfully.