### PR TITLE
fix: add timeout to fetch call to prevent CI hang

### DIFF
--- a/scripts/check-readme-sync.ts
+++ b/scripts/check-readme-sync.ts
@@ -3,7 +3,9 @@ import { readFile } from 'node:fs/promises'
 const sourceUrl =
   'https://raw.githubusercontent.com/gitignore-in/gitignore-in/main/README.md'
 
-const response = await fetch(sourceUrl)
+const response = await fetch(sourceUrl, {
+  signal: AbortSignal.timeout(10_000),
+})
 if (!response.ok) {
   throw new Error(
     `Failed to fetch upstream README: ${response.status} ${response.statusText}`,


### PR DESCRIPTION
## Summary

`scripts/check-readme-sync.ts` calls `fetch()` against GitHub raw
without a timeout. When `raw.githubusercontent.com` is slow or
temporarily unreachable, `bun run check:readme` (and therefore
`bun run lint`) blocks indefinitely — stalling the Lint step in both
`test.yml` and `octocov.yml` until the job-level timeout kills it.

Add `AbortSignal.timeout(10_000)` so the fetch fails with a clear
`TimeoutError` after 10 seconds instead of hanging the runner silently.

## Changes

- `scripts/check-readme-sync.ts`: pass `signal: AbortSignal.timeout(10_000)` to `fetch()`

## Verification

- `bun run lint` (biome check): passes (no new diagnostics)
- `AbortSignal.timeout` is part of the WHATWG Fetch/Streams API, available in Bun 1.x and all modern environments used by this project

## Trade-offs

The 10-second limit is intentionally loose — a single-file fetch from
GitHub rarely needs more than a couple of seconds under normal
conditions, and a 10-second hard cap still provides clear CI failure
signal while avoiding false positives on transient slowness.
