### PR TITLE
docs: clarify raw HTML trust model and sync upstream README

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,11 @@ import rehypeRaw from 'rehype-raw'
 import remarkGfm from 'remark-gfm'
 import readmeMarkdown from './readme.md?raw'
 
+// rehype-raw is intentionally enabled so that the upstream README's raw HTML
+// elements (e.g. <img> tags for concept diagrams) render correctly.
+// Trust model: src/readme.md is kept in sync with gitignore-in/gitignore-in
+// main branch README via scripts/check-readme-sync.ts. Any raw HTML that
+// the upstream README introduces will be executed in the browser as-is.
 export default function Home() {
   return (
     <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>

--- a/src/readme.md
+++ b/src/readme.md
@@ -70,6 +70,8 @@ are case-sensitive and match the single-space forms above (`gibo dump `,
 `gi `, and `echo `). Leading indentation, tabs between command words, or
 unknown commands are preserved when `.gitignore.in` is rewritten, but they do
 not produce generated `.gitignore` entries.
+Template provider lines must contain exactly one template name after the prefix;
+write multiple templates as separate lines instead of `gibo dump Rust macOS`.
 
 `echo` lines are parsed with shell-like quoting and then normalized as command
 arguments. For example, `echo '!.gitignore'` emits `!.gitignore`, and repeated
@@ -138,6 +140,9 @@ Exit status values are:
 - `echo <line>` and `# ...` have no external dependency.
 
 If a `.gitignore.in` mixes `gibo` and `gi` lines, both prerequisites apply.
+Catalog lookup commands such as `search` and `add` load provider template lists
+best-effort: if one provider list is temporarily unavailable, templates from the
+other provider remain usable.
 
 ## Installation
 


### PR DESCRIPTION
## Summary

- Add a comment to `src/index.tsx` documenting why `rehype-raw` is enabled and its trust model
- Sync `src/readme.md` with the upstream `gitignore-in/gitignore-in` README (two new documentation paragraphs)

## Motivation

`rehype-raw` was enabled to render the `<img>` tag in the upstream README, but this behavior
was not documented anywhere. Future readers or reviewers could misread the plugin list as
unnecessary and remove it, or not realize that raw HTML from upstream is executed in the browser.

The comment makes the intent and trust model explicit:
- `rehype-raw` is intentionally active
- `src/readme.md` is synced from `gitignore-in/gitignore-in` main branch README
- Raw HTML in the upstream README will be rendered as-is

## Changes

**`src/index.tsx`**: Added a comment above the `Home` component explaining `rehype-raw` usage
and the trust model (content is controlled by the same org, sync enforced by `check-readme-sync.ts`).

**`src/readme.md`**: Sync with upstream README as of today. Adds two new documentation paragraphs:
- Template provider lines must contain exactly one template name per line
- Catalog lookup commands load provider template lists best-effort

## Verification

- `bun run lint` passes (biome + check-readme-sync both pass)
- No behavior changes; comment is documentation only
