### PR TITLE
ci: enforce octocov coverage threshold

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,5 +1,6 @@
 # https://github.com/k1LoW/octocov?tab=readme-ov-file#configuration
 coverage:
+  acceptable: current >= 80%
   paths:
     - coverage/cobertura-coverage.xml
 codeToTestRatio:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig(async () => {
         extension: ['.ts', '.tsx'],
         requireEnv: true,
         cypress: true,
+        forceBuildInstrument: true,
       }),
     ],
     publicDir: resolve(__dirname, 'public'),


### PR DESCRIPTION
## Summary
- Add an octocov coverage acceptance gate so coverage reporting can fail CI when coverage drops below 80%.
- Enable build-time Istanbul instrumentation when `CYPRESS_COVERAGE=true`, so the existing Vite preview coverage workflow produces a non-empty Cobertura report.

## Dependency
- This PR is based on #874 because that branch already fixes the current README sync baseline required by `bun run lint`.

## Validation
- `bun install --frozen-lockfile`
- `bun x biome check --config-path=biome.json --vcs-enabled=false src cypress scripts package.json .octocov.yml vite.config.ts`
- `bun run check:readme`
- `bun run build`
- Vite preview + `bun run test`
- `CYPRESS_COVERAGE=true` build + Vite preview + `bun run test:coverage` + `bun run coverage:report`
- `go run github.com/k1LoW/octocov@latest --config .octocov.yml`
- `bun x madge --circular src`
- `typos .octocov.yml vite.config.ts`
- `git diff --check`
