### PR TITLE
docs: add CHANGELOG and deployment runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+This project uses continuous deployment: every commit merged to `main` is automatically
+deployed to [gitignore.in](https://gitignore.in) via GitHub Pages.
+
+Notable changes are recorded here. For a complete history of every deployment, see the
+[`gh-pages` branch commit log](https://github.com/gitignore-in/website/commits/gh-pages)
+or the [Actions run history](https://github.com/gitignore-in/website/actions/workflows/publish.yml).
+
+## [Unreleased]
+
+<!-- Record notable changes here before the next release point. -->
+
+## Deployment history
+
+<!-- Format: `YYYY-MM-DD — <short description> (<commit SHA or PR link>)` -->

--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -1,0 +1,34 @@
+# Deploying
+
+## How it works
+
+This site uses continuous deployment via GitHub Actions:
+
+1. A pull request is opened against `main`
+2. CI (lint, build) runs on the PR
+3. After merging to `main`, the [`Publish Website`](https://github.com/gitignore-in/website/actions/workflows/publish.yml) workflow:
+   - Runs `bun install` and `bun run build`
+   - Pushes the built output to the `gh-pages` branch via `peaceiris/actions-gh-pages`
+4. GitHub Pages serves the `gh-pages` branch at [gitignore.in](https://gitignore.in)
+
+## Tracking what is deployed
+
+- **Latest deploy**: the most recent green run of the `Publish Website` workflow
+- **Deploy history**: [`gh-pages` branch commit log](https://github.com/gitignore-in/website/commits/gh-pages) — each deploy adds one commit
+- **Change history**: [`CHANGELOG.md`](./CHANGELOG.md) — notable changes are recorded there
+
+## Rollback
+
+To rollback to a previous deployment:
+
+1. Identify the target `gh-pages` commit SHA from the branch history
+2. On a local clone, revert the `gh-pages` branch:
+   ```sh
+   git checkout gh-pages
+   git reset --hard <target-sha>
+   git push --force origin gh-pages
+   ```
+3. GitHub Pages will serve the reverted content within seconds
+
+Alternatively, revert the problematic commit on `main` and merge via a PR,
+which triggers a fresh deploy.


### PR DESCRIPTION
## Summary

- Add `CHANGELOG.md` to document the continuous deployment model and provide a template for recording notable changes
- Add `DEPLOYING.md` with explicit rollback instructions for the `gh-pages` branch

## Background

The site deploys automatically on every push to `main` via GitHub Actions + GitHub Pages.
Previously there was no written record of what changed between deployments, and no documented
rollback procedure.

## Changes

- `CHANGELOG.md`: documents the CD model, links to `gh-pages` commit history and Actions run
  history for the full deployment log, and provides an `[Unreleased]` section template
- `DEPLOYING.md`: explains the full deploy pipeline and two rollback paths
  (force-reset `gh-pages` branch, or revert on `main`)

## Trade-offs

This is a documentation-only change. It does not add automated release tagging or
GitHub Releases — those would require changes to the publish workflow and are left
as a future improvement.