### PR TITLE
Improve workflow action comments and deploy provenance

### DIFF
--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -13,4 +13,4 @@ jobs:
   update-gitignore:
     runs-on: ubuntu-latest
     steps:
-      - uses: gitignore-in/gh-action@98ab8a7225c88b81167bfef156dbad83c554aaf4
+      - uses: gitignore-in/gh-action@98ab8a7225c88b81167bfef156dbad83c554aaf4 # v0.2.3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,3 +33,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./out
           cname: gitignore.in
+          commit_message: "Deploy ${{ github.sha }} from run ${{ github.run_id }}"

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -16,6 +16,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Check spelling
-        uses: crate-ci/typos@37bb98842b0d8c4ffebdb75301a13db0267cef89 # master
+        uses: crate-ci/typos@37bb98842b0d8c4ffebdb75301a13db0267cef89 # v1.47.2
         # typos is a Source code spell checker
         # https://github.com/crate-ci/typos


### PR DESCRIPTION
## Summary
- Add version comments for pinned workflow action SHAs that were missing or still described as a moving branch.
- Record the source commit and workflow run ID in gh-pages deploy commits.
- Keep all pinned action SHAs unchanged.

## Verification
- `actionlint .github/workflows/*.yml`
- `git diff --check`
- `bun install --frozen-lockfile`
- `bun run lint`
- `bun run build`
- CI-style E2E: `bun x vite preview --host 127.0.0.1 --port 3000` then `bun run test`
- CI-style coverage E2E: `CYPRESS_COVERAGE=true bun x vite preview --host 127.0.0.1 --port 3000`, `bun run test:coverage`, `bun run coverage:report`
