### PR TITLE
Run README sync check before website deploy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,8 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
+      - run: bun run check:readme
+
       - run: bun run build
 
       - uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4

--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -7,7 +7,8 @@ This site uses continuous deployment via GitHub Actions:
 1. A pull request is opened against `main`
 2. CI (lint, build) runs on the PR
 3. After merging to `main`, the [`Publish Website`](https://github.com/gitignore-in/website/actions/workflows/publish.yml) workflow:
-   - Runs `bun install` and `bun run build`
+   - Runs `bun install`, `bun run check:readme`, and `bun run build`
+   - Stops before publishing if the vendored README is stale
    - Pushes the built output to the `gh-pages` branch via `peaceiris/actions-gh-pages`
 4. GitHub Pages serves the `gh-pages` branch at [gitignore.in](https://gitignore.in)
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,9 +7,9 @@ import readmeMarkdown from './readme.md?raw'
 
 // rehype-raw is intentionally enabled so that the upstream README's raw HTML
 // elements (e.g. <img> tags for concept diagrams) render correctly.
-// Trust model: src/readme.md is kept in sync with gitignore-in/gitignore-in
-// main branch README via scripts/check-readme-sync.ts. Any raw HTML that
-// the upstream README introduces will be executed in the browser as-is.
+// Trust model: src/readme.md is checked against gitignore-in/gitignore-in's
+// main branch README in CI and the publish workflow. Any raw HTML that the
+// upstream README introduces will be executed in the browser as-is.
 export default function Home() {
   return (
     <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>


### PR DESCRIPTION
## Summary

- Add `bun run check:readme` to `.github/workflows/publish.yml` before building and publishing.
- Update `DEPLOYING.md` so the publish gate is visible to maintainers.
- Clarify the README trust-model comment in `src/index.tsx` to describe CI and publish validation.

## Verification

- `bun install --frozen-lockfile`
- `bun run format`
- `bun run lint`
- `actionlint .github/workflows/*.yml`
- `typos`
- `bun run build`
- Preview-backed `bun run test`
- `bunx madge --circular --extensions ts,tsx src scripts`
