### PR TITLE
docs: add root README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# gitignore-in/website
+
+Source code for [gitignore.in](https://gitignore.in) — a web interface for generating `.gitignore` files.
+
+## Stack
+
+- React 19 + Vite + TypeScript
+- Runtime: bun
+- Lint/format: Biome
+- E2E tests: Cypress
+
+## Local development
+
+```sh
+bun install
+bun run dev        # http://localhost:3000
+bun run lint       # Biome check + readme sync check
+bun run build      # production build
+```
+
+## Deployment
+
+See [DEPLOYING.md](./DEPLOYING.md) for the deployment process and rollback instructions.
+
+## Change history
+
+See [CHANGELOG.md](./CHANGELOG.md) for notable changes.
+
+## Related
+
+- [gitignore-in/gitignore-in](https://github.com/gitignore-in/gitignore-in) — the gitignore data source that this site renders


### PR DESCRIPTION
## Summary

The repository had no `README.md` at the root. The GitHub top page showed
"No description, website, or topics provided." and visitors had no entry
point to understand the project.

- Add `README.md` covering project purpose, stack, local development
  commands, and links to `DEPLOYING.md` and `CHANGELOG.md`

`src/readme.md` (the site content synced from `gitignore-in/gitignore-in`)
is unchanged — the new `README.md` is a separate repository-level document.

## Test plan

- [ ] `bun run lint` passes (Biome + readme sync check)
- [ ] `bun run build` passes
- [ ] GitHub repo top page shows the README