### PR TITLE
chore: add LICENSE (MIT) and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+## Development setup
+
+```sh
+bun install
+bun run dev    # http://localhost:3000
+```
+
+## Before submitting a PR
+
+```sh
+bun run lint   # Biome check + readme sync check
+bun run build  # verify the production build
+```
+
+## Scope
+
+This repository contains the website source code for [gitignore.in](https://gitignore.in).
+The `.gitignore` data itself lives in [gitignore-in/gitignore-in](https://github.com/gitignore-in/gitignore-in).
+
+- Bug fixes and improvements to the site UI belong here.
+- Changes to `.gitignore` content belong in `gitignore-in/gitignore-in`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 gitignore-in
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

The repository had no license file, leaving the legal status unclear
for anyone wanting to reference or build on the source code. A minimal
`CONTRIBUTING.md` was also missing, leaving no guidance for external
contributors.

- Add `LICENSE` (MIT) to clarify usage rights
- Add `CONTRIBUTING.md` with development setup and contribution scope
- Repository topics set separately via the GitHub API:
  `gitignore`, `typescript`, `react`, `vite`, `website`

`gitignore-in/gh-action` already uses MIT; this aligns the website repo
with that convention.

## Test plan

- [ ] `bun run lint` passes
- [ ] `bun run build` passes
- [ ] GitHub community profile shows license and contributing guide