### PR TITLE
security: sanitize raw HTML from upstream README with rehype-sanitize

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "react-dom": "19.2.6",
         "react-markdown": "^10.1.0",
         "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "typescript": "6.0.3",
         "vite": "^8.0.13",
@@ -737,6 +738,8 @@
 
     "hast-util-raw": ["hast-util-raw@9.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "hast-util-from-parse5": "^8.0.0", "hast-util-to-parse5": "^8.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "parse5": "^7.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw=="],
 
+    "hast-util-sanitize": ["hast-util-sanitize@5.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "unist-util-position": "^5.0.0" } }, "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg=="],
+
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
 
     "hast-util-to-parse5": ["hast-util-to-parse5@8.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA=="],
@@ -1076,6 +1079,8 @@
     "regjsparser": ["regjsparser@0.13.1", "", { "dependencies": { "jsesc": "~3.1.0" }, "bin": { "regjsparser": "bin/parser" } }, "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw=="],
 
     "rehype-raw": ["rehype-raw@7.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-raw": "^9.0.0", "vfile": "^6.0.0" } }, "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww=="],
+
+    "rehype-sanitize": ["rehype-sanitize@6.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-sanitize": "^5.0.0" } }, "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg=="],
 
     "release-zalgo": ["release-zalgo@1.0.0", "", { "dependencies": { "es6-error": "^4.0.1" } }, "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA=="],
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-dom": "19.2.6",
     "react-markdown": "^10.1.0",
     "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "typescript": "6.0.3",
     "vite": "^8.0.13"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,17 +2,21 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import ReactMarkdown from 'react-markdown'
 import rehypeRaw from 'rehype-raw'
+import rehypeSanitize from 'rehype-sanitize'
 import remarkGfm from 'remark-gfm'
 import readmeMarkdown from './readme.md?raw'
 
-// rehype-raw is intentionally enabled so that the upstream README's raw HTML
-// elements (e.g. <img> tags for concept diagrams) render correctly.
-// Trust model: src/readme.md is kept in sync with gitignore-in/gitignore-in
-// main branch README via scripts/check-readme-sync.ts. Any raw HTML that
-// the upstream README introduces will be executed in the browser as-is.
+// rehype-raw parses raw HTML in the upstream README (e.g. <img> tags for
+// concept diagrams). rehype-sanitize follows immediately to strip dangerous
+// elements and attributes before the tree reaches the browser.
+// Trust model: src/readme.md is synced from gitignore-in/gitignore-in main
+// via scripts/check-readme-sync.ts; sanitization is the technical backstop.
 export default function Home() {
   return (
-    <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      rehypePlugins={[rehypeRaw, rehypeSanitize]}
+    >
       {readmeMarkdown}
     </ReactMarkdown>
   )


### PR DESCRIPTION
## Summary

`rehype-raw` lets raw HTML in `src/readme.md` pass through to the browser, which is intentional so upstream `<img>` tags render correctly. Without a sanitization layer any dangerous HTML that enters `src/readme.md` (via the upstream sync or a PR) would execute in the browser as-is.

This PR adds `rehype-sanitize` (using its `defaultSchema`) immediately after `rehype-raw` in the plugin pipeline. The default schema is based on GitHub's own Markdown sanitization allowlist: it allows safe elements (`img`, `a`, headings, code blocks, tables, etc.) while stripping `<script>`, `<iframe>`, inline event handlers, and `javascript:` URIs.

## Changes

- `src/index.tsx`: import `rehype-sanitize` and add it as the second entry in `rehypePlugins`; update trust-model comment
- `package.json` / `bun.lock`: add `rehype-sanitize@^6.0.0` as a dependency

## Verification

- `bun run lint` — passes (biome + readme sync check)
- `bun run build` — passes (305 modules, no new warnings)
- `bunx tsc --noEmit` — no type errors
- collateral check — clean (no version-shrink, gha-inline-script, or too-many-files findings)
