### PR TITLE
ci: add timeout-minutes to all jobs and concurrency to gitignore-in.yml

### DIFF
--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -9,8 +9,13 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   update-gitignore:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: gitignore-in/gh-action@98ab8a7225c88b81167bfef156dbad83c554aaf4

--- a/.github/workflows/happy.yml
+++ b/.github/workflows/happy.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   happy:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     name: happy
     steps:
       - uses: kitsuyui/happy-commit@b8724714862e1b643122b8f233b3aaca26b9825d # v0.9

--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   octocov:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       CYPRESS_COVERAGE: "true"
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ jobs:
   deploy:
     name: Publish
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write
     steps:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

All six GitHub Actions jobs were missing `timeout-minutes`, leaving GitHub's default 6-hour limit in place. In addition, `gitignore-in.yml` — the only scheduled workflow with write permissions (`contents: write`, `pull-requests: write`) — had no `concurrency` guard, allowing duplicate runs to create conflicting PRs.

## Changes

- `test.yml`, `octocov.yml`: `timeout-minutes: 30` (Cypress E2E jobs)
- `publish.yml`: `timeout-minutes: 20` (build + gh-pages deploy)
- `gitignore-in.yml`: `timeout-minutes: 15` + `concurrency` group (schedule workflow)
- `happy.yml`, `spellcheck.yml`: `timeout-minutes: 10` (lightweight check jobs)

Concurrency for `gitignore-in.yml` uses `cancel-in-progress: false` so an already-running update is allowed to finish; a queued duplicate run is cancelled instead.

## Verification

- `actionlint` reports no issues across all six workflow files.
- `bun run lint` passes (only a pre-existing biome deprecation warning unrelated to this change).

## Trade-offs

Timeouts are conservative estimates; the actual wall-clock for Cypress E2E on the current hardware is well under 10 minutes. If a slower runner tier is introduced later, timeouts may need upward adjustment.
