### PR TITLE
docs: clarify stdout/stderr contract for all subcommands

### DIFF
--- a/src/readme.md
+++ b/src/readme.md
@@ -120,8 +120,10 @@ $ gitignore.in restore
 ## Output and Exit Status
 
 `gitignore.in search` writes matching templates to stdout as tab-separated
-`provider<TAB>template` rows. Progress messages and errors are written to
-stderr so stdout can be piped to other tools.
+`provider<TAB>template` rows. All other subcommands (`gitignore.in`, `add`,
+`remove`, `infer`, `restore`) produce no stdout output. Progress messages such
+as "Generated .gitignore" and all errors are written to stderr across all
+subcommands.
 
 Exit status values are:
 


### PR DESCRIPTION
## Summary

Syncs `src/readme.md` with the upstream fix in gitignore-in/gitignore-in#360.

The "Output and Exit Status" section only documented the stdout/stderr contract
for `search`. This change extends the description to clarify that all other
subcommands (`gitignore.in`, `add`, `remove`, `infer`, `restore`) produce no
stdout output — progress messages go to stderr only.

## Dependency

This PR mirrors [gitignore-in/gitignore-in#360](https://github.com/gitignore-in/gitignore-in/pull/360).
The `bun run check:readme` step will pass once that upstream PR is merged to main.

## What changed

`src/readme.md` — expanded "Output and Exit Status" paragraph to document the
stdout/stderr contract for all subcommands, not just `search`.
