### PR TITLE
ci: add script to set required status checks on main branch

### DIFF
--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Set required status checks for the main branch.
+# Requires: gh CLI authenticated as a repository admin.
+#
+# Usage:
+#   ./scripts/setup-branch-protection.sh
+#
+# Required checks: test (test.yml), happy (happy.yml)
+
+set -eu
+
+REPO="gitignore-in/website"
+BRANCH="main"
+
+printf '%s\n' "Setting required status checks on ${REPO}@${BRANCH}..."
+
+printf '%s' '{
+  "strict": false,
+  "checks": [
+    {"context": "test"},
+    {"context": "happy"}
+  ]
+}' | gh api "repos/${REPO}/branches/${BRANCH}/protection/required_status_checks" \
+      --method PATCH \
+      --input -
+
+printf '%s\n' "Done. Required checks: test, happy"


### PR DESCRIPTION
## Summary

The main branch had branch protection enabled but with no required status checks
(`checks: []`), meaning CI failures did not block PR merges.

This PR adds `scripts/setup-branch-protection.sh`, which documents the intended
required checks (`test` from `test.yml` and `happy` from `happy.yml`) and applies
them via the GitHub API.

The settings have been applied directly (`test` and `happy` are now required)
as part of this fix. The script serves as reproducible documentation for re-applying
the configuration after any future reset.

## Changes

- `scripts/setup-branch-protection.sh`: Admin-runnable script that sets `test` and
  `happy` as required status checks on the `main` branch. Run once by a repo admin
  using the `gh` CLI.

## Verification

- `actionlint`: no workflow files changed.
- `typos`: passes.
- Required checks applied via `gh api` — confirmed with
  `gh api repos/gitignore-in/website/branches/main/protection/required_status_checks`.