### PR TITLE
fix: add SVG favicon and update link reference

### DIFF
--- a/cypress/e2e/app.cy.ts
+++ b/cypress/e2e/app.cy.ts
@@ -10,7 +10,9 @@ describe('App Home', () => {
   })
 
   it('should serve the SVG favicon', () => {
-    cy.request('/favicon.svg').its('status').should('eq', 200)
+    cy.request('http://localhost:3000/favicon.svg')
+      .its('status')
+      .should('eq', 200)
     cy.visit('http://localhost:3000')
     cy.get('link[rel="icon"]')
       .should('have.attr', 'type', 'image/svg+xml')

--- a/cypress/e2e/app.cy.ts
+++ b/cypress/e2e/app.cy.ts
@@ -16,6 +16,7 @@ describe('App Home', () => {
     cy.visit('http://localhost:3000')
     cy.get('link[rel="icon"]')
       .should('have.attr', 'type', 'image/svg+xml')
-      .and('have.attr', 'href', '/favicon.svg')
+      // Vite's `base: './'` rewrites the built link href to a relative path.
+      .and('have.attr', 'href', './favicon.svg')
   })
 })

--- a/cypress/e2e/app.cy.ts
+++ b/cypress/e2e/app.cy.ts
@@ -8,4 +8,12 @@ describe('App Home', () => {
       .should('have.attr', 'src')
       .and('include', 'github.com/gitignore-in/gitignore-in/assets')
   })
+
+  it('should serve the SVG favicon', () => {
+    cy.request('/favicon.svg').its('status').should('eq', 200)
+    cy.visit('http://localhost:3000')
+    cy.get('link[rel="icon"]')
+      .should('have.attr', 'type', 'image/svg+xml')
+      .and('have.attr', 'href', '/favicon.svg')
+  })
 })

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" role="img" aria-label="gitignore.in">
+  <title>gitignore.in</title>
+  <rect width="32" height="32" rx="4" fill="#1a1a2e"/>
+  <text x="16" y="22" font-family="monospace" font-size="14" font-weight="bold" fill="#e0e0e0" text-anchor="middle">.gi</text>
+</svg>

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
     <link rel="canonical" href="https://gitignore.in/" />
-    <link rel="icon" href="/favicon.ico" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="description" content="gitignore.in generates .gitignore files from editable .gitignore.in templates." />
     <script type="module" src="/index.tsx"></script>
     <title>gitignore.in</title>


### PR DESCRIPTION
## Summary

`src/index.html` referenced `/favicon.ico` via `<link rel="icon">`, but `public/favicon.ico` did not exist. Every page load caused a 404 for the favicon, producing console errors for visitors and crawlers.

## Changes

- `public/favicon.svg` — adds a minimal SVG favicon for gitignore.in with an accessible `<title>` element
- `src/index.html` — updates the `<link rel="icon">` to reference `/favicon.svg` with the correct MIME type (`image/svg+xml`)
- `cypress/e2e/app.cy.ts` — adds a test that verifies `/favicon.svg` returns HTTP 200 and that the `<link rel="icon">` attribute is set correctly

## Verification

- `bun run lint` passes (biome check, no errors)
- `bun run format` passes (no fixes needed)
- Collateral check: clean
- SVG favicon includes `<title>gitignore.in</title>` and `aria-label` for accessibility

## Trade-offs

SVG favicons are not supported in IE or very old browsers. The site already uses React 19, so IE support is not in scope. Browsers that auto-request `/favicon.ico` directly (rather than following the `<link>` tag) will still receive a 404; this is unchanged from the prior state where `favicon.ico` was also absent.
