### PR TITLE
fix: add explicit read-only permissions to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

`test.yml` is the only workflow without an explicit `permissions:` block. All five other workflows already declare their permissions; this aligns `test.yml` with the same least-privilege pattern.

## Change

Add `permissions: contents: read` at the workflow level in `.github/workflows/test.yml`.

`test.yml` runs lint, build, and Cypress E2E tests on `pull_request` — a read-only workflow that needs no write access to the repository. The explicit `contents: read` declaration prevents it from inheriting broader repository-default permissions (which could include write access depending on org settings).

## Verification

- Matches the pattern used by `spellcheck.yml` (same `pull_request` trigger, same `contents: read`)
- `actionlint` reports no issues on the modified file
- No functional change to the workflow steps