### PR TITLE
fix(ci): replace sleep-1 polling loop with wait-on and fix trap cleanup

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -43,16 +43,9 @@ jobs:
         run: |
           bun x vite preview --host 127.0.0.1 --port 3000 >/tmp/gitignore-in-website-vite.log 2>&1 &
           vite_pid=$!
-          trap 'kill $vite_pid; cat /tmp/gitignore-in-website-vite.log' EXIT
+          trap 'kill $vite_pid 2>/dev/null; wait $vite_pid 2>/dev/null || true; cat /tmp/gitignore-in-website-vite.log' EXIT
 
-          for _ in $(seq 1 60); do
-            if curl --fail --silent http://127.0.0.1:3000 >/dev/null; then
-              break
-            fi
-            sleep 1
-          done
-
-          curl --fail --silent http://127.0.0.1:3000 >/dev/null
+          bun x wait-on http://127.0.0.1:3000 --timeout 60000
           bun run test:coverage
 
       - name: Build coverage report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,14 +33,7 @@ jobs:
         run: |
           bun x vite preview --host 127.0.0.1 --port 3000 >/tmp/gitignore-in-website-vite.log 2>&1 &
           vite_pid=$!
-          trap 'kill $vite_pid; cat /tmp/gitignore-in-website-vite.log' EXIT
+          trap 'kill $vite_pid 2>/dev/null; wait $vite_pid 2>/dev/null || true; cat /tmp/gitignore-in-website-vite.log' EXIT
 
-          for _ in $(seq 1 60); do
-            if curl --fail --silent http://127.0.0.1:3000 >/dev/null; then
-              break
-            fi
-            sleep 1
-          done
-
-          curl --fail --silent http://127.0.0.1:3000 >/dev/null
+          bun x wait-on http://127.0.0.1:3000 --timeout 60000
           bun run test


### PR DESCRIPTION
## Summary

Both `test.yml` and `octocov.yml` used a hand-rolled bash loop to wait for
`vite preview` to become ready before running Cypress tests. The pattern had
two reliability issues:

1. **Fixed-interval polling**: `sleep 1` between each `curl` attempt causes
   either excess waiting or a hard timeout that doesn't clearly signal failure.
2. **No `wait` after `kill`**: The `EXIT` trap called `kill $vite_pid` but
   never called `wait $vite_pid`, so vite could still hold port 3000 when the
   next cleanup step ran.

## Changes

- **`.github/workflows/test.yml`** and **`.github/workflows/octocov.yml`**:
  - Replace the custom `for`/`sleep`/`curl` polling loop with
    `bun x wait-on http://127.0.0.1:3000 --timeout 60000`. `wait-on` polls
    with adaptive backoff, confirms an HTTP 2xx response (not just port open),
    and exits non-zero on timeout — cleanly surfacing the failure.
  - Fix the `EXIT` trap: `kill $vite_pid 2>/dev/null; wait $vite_pid 2>/dev/null || true`
    so the vite process fully exits before the runner continues.

## Verification

- `bun run lint` (biome check): passed
- `check-pr-collateral.py`: clean
- Behaviour is equivalent: both approaches wait up to 60 s for HTTP 200 on
  port 3000 before running Cypress.
