### PR TITLE
ci: show vite server logs only on failure

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           bun x vite preview --host 127.0.0.1 --port 3000 >/tmp/gitignore-in-website-vite.log 2>&1 &
           vite_pid=$!
-          trap 'kill $vite_pid; cat /tmp/gitignore-in-website-vite.log' EXIT
+          trap 'kill $vite_pid' EXIT
 
           for _ in $(seq 1 60); do
             if curl --fail --silent http://127.0.0.1:3000 >/dev/null; then
@@ -54,6 +54,10 @@ jobs:
 
           curl --fail --silent http://127.0.0.1:3000 >/dev/null
           bun run test:coverage
+
+      - name: Show vite server logs
+        if: failure()
+        run: cat /tmp/gitignore-in-website-vite.log
 
       - name: Build coverage report
         run: bun run coverage:report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           bun x vite preview --host 127.0.0.1 --port 3000 >/tmp/gitignore-in-website-vite.log 2>&1 &
           vite_pid=$!
-          trap 'kill $vite_pid; cat /tmp/gitignore-in-website-vite.log' EXIT
+          trap 'kill $vite_pid' EXIT
 
           for _ in $(seq 1 60); do
             if curl --fail --silent http://127.0.0.1:3000 >/dev/null; then
@@ -44,3 +44,7 @@ jobs:
 
           curl --fail --silent http://127.0.0.1:3000 >/dev/null
           bun run test
+
+      - name: Show vite server logs
+        if: failure()
+        run: cat /tmp/gitignore-in-website-vite.log


### PR DESCRIPTION
## Summary

Fix the CI EXIT trap in `test.yml` and `octocov.yml` so that the vite server log is only shown when the workflow fails, not on every run.

## Problem

Both workflows had this trap:

```sh
trap 'kill $vite_pid; cat /tmp/gitignore-in-website-vite.log' EXIT
```

The `cat` runs unconditionally — on success and failure alike. Diagnostic logs should help debug failures, not appear as noise when tests pass. On a successful run, the vite log output adds clutter without value.

## Change

Split the log display into a separate step using GitHub Actions' `if: failure()`:

```yaml
- name: E2E Test
  run: |
    ...
    trap 'kill $vite_pid' EXIT   # cleanup only
    ...

- name: Show vite server logs
  if: failure()
  run: cat /tmp/gitignore-in-website-vite.log
```

This is the idiomatic GitHub Actions pattern for failure-only diagnostics. The trap now only handles cleanup; the log display is conditional.

Applied the same fix to both `test.yml` (E2E Test step) and `octocov.yml` (Test with coverage step), which had the identical pattern.

## Verification

- On success: vite server is killed by the trap; log step is skipped.
- On failure: vite server is killed by the trap; log step runs and displays the vite output for debugging.
