### PR TITLE
Remove unused Cypress fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# gitignore.in website
+
+Static website for [gitignore.in](https://gitignore.in).
+
+## Development
+
+Install dependencies with:
+
+```sh
+bun install --frozen-lockfile
+```
+
+Run the local checks with:
+
+```sh
+bun run lint
+bun run build
+bun run test:unit
+```
+
+`bun run lint` runs Biome and verifies that `src/readme.md` matches the
+upstream `gitignore-in/gitignore-in` README at the pinned commit in
+`scripts/check-readme-sync.ts`. The README sync check fetches that upstream
+file over the network, so lint requires network access.
+
+For the full Cypress check, start the preview server before running the test:
+
+```sh
+bun x vite preview --host 127.0.0.1 --port 3000
+bun run test
+```

--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,5 +1,0 @@
-{
-  "name": "Using fixtures to represent data",
-  "email": "hello@cypress.io",
-  "body": "Fixtures are a great way to mock data for responses to routes"
-}

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "start": "vite preview --port 3000",
     "lint": "biome check . && bun run check:readme",
     "check:readme": "bun scripts/check-readme-sync.ts",
-    "test": "cypress run",
-    "test:coverage": "cypress run",
+    "test": "bun run test:unit && cypress run",
+    "test:unit": "bun test scripts/check-readme-sync.test.ts",
+    "test:coverage": "bun run test:unit && cypress run",
     "coverage:report": "nyc report --reporter=cobertura --report-dir coverage",
     "format": "biome check --write ."
   },

--- a/scripts/check-readme-sync.test.ts
+++ b/scripts/check-readme-sync.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from 'bun:test'
+
+import {
+  checkReadmeSync,
+  sourceUrl,
+  upstreamReadmeCommit,
+} from './check-readme-sync'
+
+test('fetches the pinned upstream README URL', async () => {
+  await checkReadmeSync(
+    async (input) => {
+      expect(input).toBe(sourceUrl)
+      return new Response('readme')
+    },
+    async () => 'readme',
+  )
+})
+
+test('reports the pinned upstream commit when fetch rejects', async () => {
+  await expect(
+    checkReadmeSync(
+      async () => {
+        throw new Error('offline')
+      },
+      async () => 'readme',
+    ),
+  ).rejects.toThrow(
+    `Failed to fetch upstream README at ${upstreamReadmeCommit}: Error: offline`,
+  )
+})

--- a/scripts/check-readme-sync.ts
+++ b/scripts/check-readme-sync.ts
@@ -1,24 +1,53 @@
 import { readFile } from 'node:fs/promises'
 
-const sourceUrl =
-  'https://raw.githubusercontent.com/gitignore-in/gitignore-in/main/README.md'
+type Fetcher = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>
+type LocalReadmeReader = () => Promise<string>
 
-const response = await fetch(sourceUrl, {
-  signal: AbortSignal.timeout(10_000),
-})
-if (!response.ok) {
-  throw new Error(
-    `Failed to fetch upstream README: ${response.status} ${response.statusText}`,
-  )
+export const upstreamReadmeCommit = '42f443ce633cb454058569a584bd4c08c44d710f'
+export const sourceUrl = `https://raw.githubusercontent.com/gitignore-in/gitignore-in/${upstreamReadmeCommit}/README.md`
+
+const localReadmeUrl = new URL('../src/readme.md', import.meta.url)
+
+export const fetchUpstreamReadme = async (
+  fetcher: Fetcher = fetch,
+): Promise<string> => {
+  const response = await fetcher(sourceUrl, {
+    signal: AbortSignal.timeout(10_000),
+  }).catch((cause: unknown) => {
+    throw new Error(
+      `Failed to fetch upstream README at ${upstreamReadmeCommit}: ${cause}`,
+      { cause },
+    )
+  })
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch upstream README at ${upstreamReadmeCommit}: ${response.status} ${response.statusText}`,
+    )
+  }
+
+  return response.text()
 }
 
-const [upstreamReadme, localReadme] = await Promise.all([
-  response.text(),
-  readFile(new URL('../src/readme.md', import.meta.url), 'utf8'),
-])
+export const checkReadmeSync = async (
+  fetcher: Fetcher = fetch,
+  readLocalReadme: LocalReadmeReader = () => readFile(localReadmeUrl, 'utf8'),
+): Promise<void> => {
+  const [upstreamReadme, localReadme] = await Promise.all([
+    fetchUpstreamReadme(fetcher),
+    readLocalReadme(),
+  ])
 
-if (localReadme !== upstreamReadme) {
-  throw new Error(
-    'src/readme.md is out of sync with gitignore-in/gitignore-in README.md',
-  )
+  if (localReadme !== upstreamReadme) {
+    throw new Error(
+      'src/readme.md is out of sync with gitignore-in/gitignore-in README.md',
+    )
+  }
+}
+
+if (import.meta.main) {
+  await checkReadmeSync()
 }


### PR DESCRIPTION
## Summary

- Remove the scaffolded Cypress `example.json` fixture.
- Keep the Cypress suite focused on the current DOM-based tests; no spec imports or loads this fixture.

## Validation

- `bun run format`
- `bun run lint`
- `bun run build`
- `bun run test` with Vite preview on `127.0.0.1:3000`
- `CYPRESS_COVERAGE=true bun run test:coverage` with Vite preview on `127.0.0.1:3000`
- `bunx madge --circular --extensions ts,tsx src scripts`
- `bunx actionlint .github/workflows/*.yml`
- `bunx typos`
- `git diff --check`
- static grep confirmed no Cypress fixture references remain
- collateral check: clean

## Dependency

This PR is based on #885 because the current `main` branch has an unrelated README sync lint failure. The change in this branch is limited to removing the unused Cypress fixture.
