### PR TITLE
fix: report empty upstream README responses

### DIFF
--- a/scripts/check-readme-sync.test.ts
+++ b/scripts/check-readme-sync.test.ts
@@ -28,3 +28,30 @@ test('reports the pinned upstream commit when fetch rejects', async () => {
     `Failed to fetch upstream README at ${upstreamReadmeCommit}: Error: offline`,
   )
 })
+
+test('reports an empty upstream body as a fetch failure', async () => {
+  await expect(
+    checkReadmeSync(
+      async () => new Response(''),
+      async () => 'readme',
+    ),
+  ).rejects.toThrow(
+    `Failed to fetch upstream README at ${upstreamReadmeCommit}: response body was empty`,
+  )
+})
+
+test('reports upstream body read failures before comparing content', async () => {
+  const response = new Response('readme')
+  response.text = async () => {
+    throw new Error('stream interrupted')
+  }
+
+  await expect(
+    checkReadmeSync(
+      async () => response,
+      async () => 'readme',
+    ),
+  ).rejects.toThrow(
+    `Failed to read upstream README at ${upstreamReadmeCommit}: Error: stream interrupted`,
+  )
+})

--- a/scripts/check-readme-sync.ts
+++ b/scripts/check-readme-sync.ts
@@ -11,6 +11,25 @@ export const sourceUrl = `https://raw.githubusercontent.com/gitignore-in/gitigno
 
 const localReadmeUrl = new URL('../src/readme.md', import.meta.url)
 
+const readResponseText = async (response: Response): Promise<string> => {
+  try {
+    return await response.text()
+  } catch (cause) {
+    throw new Error(
+      `Failed to read upstream README at ${upstreamReadmeCommit}: ${cause}`,
+      { cause },
+    )
+  }
+}
+
+const assertResponseBodyIsNotEmpty = (upstreamReadme: string) => {
+  if (upstreamReadme.length === 0) {
+    throw new Error(
+      `Failed to fetch upstream README at ${upstreamReadmeCommit}: response body was empty`,
+    )
+  }
+}
+
 export const fetchUpstreamReadme = async (
   fetcher: Fetcher = fetch,
 ): Promise<string> => {
@@ -29,7 +48,9 @@ export const fetchUpstreamReadme = async (
     )
   }
 
-  return response.text()
+  const upstreamReadme = await readResponseText(response)
+  assertResponseBodyIsNotEmpty(upstreamReadme)
+  return upstreamReadme
 }
 
 export const checkReadmeSync = async (


### PR DESCRIPTION
## Summary

- Treat an empty upstream README response body as a fetch failure before comparing README content.
- Wrap upstream response body read failures with a read-specific error.
- Add unit coverage for empty response bodies and interrupted body reads.

## Base branch

This PR is based on `fix/audit-unversioned-upstream-ref-in-lint-001` because #885 pins the upstream README URL and adds the unit-test entrypoint this change extends.

## Verification

- `bunx biome check --write scripts/check-readme-sync.ts scripts/check-readme-sync.test.ts`
- `bun test scripts/check-readme-sync.test.ts`
- `bun run lint`
- `bun run build`
- `bun x cypress install`
- `bun run test` with a local Vite preview server on port 3000
- `CYPRESS_COVERAGE=true bun run test:coverage` with a local Vite preview server on port 3000
- `bun run coverage:report`
- `bunx actionlint .github/workflows/*.yml`
- `bunx madge --circular --extensions ts,tsx src scripts`
- `bunx typos`
- `git diff --check`
- `check-pr-collateral.py --title "fix: report empty upstream README responses"`
