### PR TITLE
fix: normalize line endings and NFC in README sync check

### DIFF
--- a/scripts/check-readme-sync.ts
+++ b/scripts/check-readme-sync.ts
@@ -17,7 +17,9 @@ const [upstreamReadme, localReadme] = await Promise.all([
   readFile(new URL('../src/readme.md', import.meta.url), 'utf8'),
 ])
 
-if (localReadme !== upstreamReadme) {
+const normalize = (text: string) => text.normalize('NFC').replace(/\r\n/g, '\n')
+
+if (normalize(localReadme) !== normalize(upstreamReadme)) {
   throw new Error(
     'src/readme.md is out of sync with gitignore-in/gitignore-in README.md',
   )


### PR DESCRIPTION
## Problem

`scripts/check-readme-sync.ts` compares the local `src/readme.md` and the
upstream README using a byte-exact `\!==` comparison. This means:

- **Windows `core.autocrlf=true`**: `readFile(..., 'utf8')` preserves `\r\n`
  while `response.text()` returns `\n`-only — identical content reports as
  out of sync.
- **Unicode normalization**: if the upstream README ever gains combining
  characters or emoji, NFC vs NFD differences between local and GitHub's
  raw API response could cause false positives.

CI runs on `ubuntu-latest` only, so neither failure mode appears there.

## Fix

Add a `normalize()` helper that applies `String.prototype.normalize('NFC')`
and then replaces `\r\n` with `\n` before comparison:

```typescript
const normalize = (text: string) => text.normalize('NFC').replace(/\r\n/g, '\n')
```

Both sides are normalized before `\!==`, making the check robust to
line-ending and Unicode-normalization differences.

## Scope

Only `scripts/check-readme-sync.ts` changes. No functional change for
CI (which is Linux-only). Windows developers and future emoji/combining-char
content are the beneficiaries.
