### PR TITLE
fix: add --repo, --branch, --dry-run, and --help options to setup-branch-protection.sh

### DIFF
--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -3,25 +3,59 @@
 # Requires: gh CLI authenticated as a repository admin.
 #
 # Usage:
-#   ./scripts/setup-branch-protection.sh
+#   ./scripts/setup-branch-protection.sh [OPTIONS]
+#
+# Options:
+#   --repo OWNER/REPO   Target repository (default: gitignore-in/website)
+#   --branch BRANCH     Target branch (default: main)
+#   --dry-run           Print the gh API call without executing it
+#   --help              Show this help message
 #
 # Required checks: test (test.yml), happy (happy.yml)
+# strict=false: "Require branches to be up to date before merging" is intentionally
+#   disabled so that PRs whose branch tip has passed CI can merge without rebasing.
 
 set -eu
 
 REPO="gitignore-in/website"
 BRANCH="main"
+DRY_RUN=0
 
-printf '%s\n' "Setting required status checks on ${REPO}@${BRANCH}..."
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo)   REPO="$2";   shift 2 ;;
+    --branch) BRANCH="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1;  shift   ;;
+    --help)
+      grep '^#' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      printf 'error: unknown option: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+done
 
-printf '%s' '{
+PAYLOAD='{
   "strict": false,
   "checks": [
     {"context": "test"},
     {"context": "happy"}
   ]
-}' | gh api "repos/${REPO}/branches/${BRANCH}/protection/required_status_checks" \
-      --method PATCH \
-      --input -
+}'
+
+printf '%s\n' "Setting required status checks on ${REPO}@${BRANCH}..."
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  printf 'DRY RUN: gh api "repos/%s/branches/%s/protection/required_status_checks" --method PATCH --input -\n' \
+    "${REPO}" "${BRANCH}"
+  printf 'Payload:\n%s\n' "${PAYLOAD}"
+  exit 0
+fi
+
+printf '%s' "${PAYLOAD}" | gh api "repos/${REPO}/branches/${BRANCH}/protection/required_status_checks" \
+  --method PATCH \
+  --input -
 
 printf '%s\n' "Done. Required checks: test, happy"


### PR DESCRIPTION
## Summary

- `scripts/setup-branch-protection.sh` previously had `REPO` and `BRANCH` hardcoded with no way to override them.
- Running the script without any option check gave no safe way to preview what would happen.

## Changes

- Add `--repo OWNER/REPO` option (default: `gitignore-in/website`) to target a different repository without editing the script.
- Add `--branch BRANCH` option (default: `main`) for the same reason.
- Add `--dry-run` option that prints the `gh api` call and payload without executing it.
- Add `--help` option that prints the usage comment block.
- Add a `PAYLOAD` variable so the dry-run output matches what a live run would send.

## Verification

```sh
# Confirm --help prints usage without hitting the API
./scripts/setup-branch-protection.sh --help

# Confirm --dry-run prints the command without making a network call
./scripts/setup-branch-protection.sh --dry-run
./scripts/setup-branch-protection.sh --repo gitignore-in/website --branch main --dry-run
```