### PR TITLE
docs: add missing test and format commands to README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,8 @@ bun run dev    # http://localhost:3000
 
 ```sh
 bun run lint   # Biome check + readme sync check
+bun run format # auto-format with Biome
+bun run test   # run Cypress E2E tests
 bun run build  # verify the production build
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Source code for [gitignore.in](https://gitignore.in) — a web interface for gen
 bun install
 bun run dev        # http://localhost:3000
 bun run lint       # Biome check + readme sync check
+bun run format     # auto-format with Biome
+bun run test       # run Cypress E2E tests
 bun run build      # production build
 ```
 


### PR DESCRIPTION
## Summary

`README.md` and `CONTRIBUTING.md` were missing `bun run format` and `bun run test` from their command lists, even though both scripts exist in `package.json`.

- `format`: `biome check --write .` — auto-formats the codebase with Biome
- `test`: `cypress run` — runs the Cypress E2E test suite

Contributors following the docs would skip formatting and testing before submitting a PR, leading to CI failures as the first feedback.

## Changes

- `README.md` (Local development): added `bun run format` and `bun run test`
- `CONTRIBUTING.md` (Before submitting a PR): added `bun run format` and `bun run test`

## Validation

- `typos README.md CONTRIBUTING.md`: clean
- `git diff --check`: clean
