### PR TITLE
fix(package.json): set CYPRESS_COVERAGE=true in test:coverage script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,39 +1,39 @@
 {
-  "name": "@gitignore-in/website",
-  "version": "0.1.0",
-  "private": true,
-  "scripts": {
-    "dev": "vite dev --port 3000",
-    "build": "vite build",
-    "start": "vite preview --port 3000",
-    "lint": "biome check . && bun run check:readme",
-    "check:readme": "bun scripts/check-readme-sync.ts",
-    "test": "cypress run",
-    "test:coverage": "cypress run",
-    "coverage:report": "nyc report --reporter=cobertura --report-dir coverage",
-    "format": "biome check --write ."
-  },
-  "dependencies": {
-    "@types/node": "25.9.3",
-    "@types/react": "19.2.14",
-    "@types/react-dom": "19.2.3",
-    "react": "19.2.6",
-    "react-dom": "19.2.6",
-    "react-markdown": "^10.1.0",
-    "rehype-raw": "^7.0.0",
-    "remark-gfm": "^4.0.1",
-    "typescript": "6.0.3",
-    "vite": "^8.0.13"
-  },
-  "devDependencies": {
-    "@bahmutov/cypress-esbuild-preprocessor": "^2.2.8",
-    "@biomejs/biome": "^2.5.0",
-    "@cypress/code-coverage": "^4.0.3",
-    "@vitejs/plugin-react-swc": "^4.3.1",
-    "cypress": "^15.17.0",
-    "esbuild": "^0.28.1",
-    "nyc": "^18.0.0",
-    "vite-plugin-istanbul": "^9.0.0"
-  },
-  "packageManager": "bun@1.3.11"
+	"name": "@gitignore-in/website",
+	"version": "0.1.0",
+	"private": true,
+	"scripts": {
+		"dev": "vite dev --port 3000",
+		"build": "vite build",
+		"start": "vite preview --port 3000",
+		"lint": "biome check . && bun run check:readme",
+		"check:readme": "bun scripts/check-readme-sync.ts",
+		"test": "cypress run",
+		"test:coverage": "CYPRESS_COVERAGE=true cypress run",
+		"coverage:report": "nyc report --reporter=cobertura --report-dir coverage",
+		"format": "biome check --write ."
+	},
+	"dependencies": {
+		"@types/node": "25.9.3",
+		"@types/react": "19.2.14",
+		"@types/react-dom": "19.2.3",
+		"react": "19.2.6",
+		"react-dom": "19.2.6",
+		"react-markdown": "^10.1.0",
+		"rehype-raw": "^7.0.0",
+		"remark-gfm": "^4.0.1",
+		"typescript": "6.0.3",
+		"vite": "^8.0.13"
+	},
+	"devDependencies": {
+		"@bahmutov/cypress-esbuild-preprocessor": "^2.2.8",
+		"@biomejs/biome": "^2.5.0",
+		"@cypress/code-coverage": "^4.0.3",
+		"@vitejs/plugin-react-swc": "^4.3.1",
+		"cypress": "^15.17.0",
+		"esbuild": "^0.28.1",
+		"nyc": "^18.0.0",
+		"vite-plugin-istanbul": "^9.0.0"
+	},
+	"packageManager": "bun@1.3.11"
 }


### PR DESCRIPTION
## Problem

`package.json` defined `test:coverage` as `cypress run` — identical to `test`. Running
`bun run test:coverage` locally produced no coverage report because
`vite-plugin-istanbul` is configured with `requireEnv: true`, which skips
instrumentation unless `CYPRESS_COVERAGE=true` is set. The env var was only set
in the CI octocov workflow (`.github/workflows/octocov.yml`), making the
script name misleading for local use.

## Fix

Set `CYPRESS_COVERAGE=true` inline in the `test:coverage` script so the name
matches the behavior regardless of environment:

```diff
-    "test:coverage": "cypress run",
+    "test:coverage": "CYPRESS_COVERAGE=true cypress run",
```

Also apply biome v2.5.0 JSON formatting (tabs) to `package.json`; the file
had 2-space indentation that did not match biome's expected output.

## Verification

- `biome check package.json` — no issues
- Confirmed `CYPRESS_COVERAGE=true` enables `vite-plugin-istanbul`
  instrumentation via `requireEnv: true` in `vite.config.ts`
