### PR TITLE
docs: add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Report a problem with the gitignore.in website
+title: ""
+labels: bug
+assignees: ""
+---
+
+## Description
+
+<!-- A clear and concise description of the bug. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+<!-- What you expected to happen. -->
+
+## Actual behavior
+
+<!-- What actually happened. -->
+
+## Environment
+
+- Browser and version:
+- OS:
+- URL where the issue occurs:
+
+## Additional context
+
+<!-- Screenshots, console errors, or any other relevant information. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- What this PR does and why. -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Dependency update
+- [ ] Documentation
+- [ ] Refactor / cleanup
+
+## Test plan
+
+- [ ] `bun run lint` passes
+- [ ] `bun run build` passes
+- [ ] `bun run test:unit` passes
+- [ ] Manual smoke test in browser (if applicable)
+
+## Related issues
+
+<!-- Closes #123 -->


### PR DESCRIPTION
## Summary

Adds GitHub issue and pull request templates to guide contributors with the
information needed for triage and reviews.

Without templates, issues and PRs arrive as free-form text, which increases
triage cost — especially for bug reports that lack reproduction steps or
environment details.

## Changes

- `.github/ISSUE_TEMPLATE/bug_report.md`: bug report template with steps to
  reproduce, expected/actual behavior, browser+OS, and URL fields
- `.github/PULL_REQUEST_TEMPLATE.md`: PR template with summary, change type
  checklist, test plan checklist, and related issues section

## Test plan

- [ ] Templates appear in the GitHub UI when opening a new issue or PR
- No code changes; `bun run lint`, `bun run build`, and `bun run test:unit`
  are unaffected

## Trade-offs

These are minimal templates. A more structured YAML form config
(e.g. `config.yml` to disable blank issues) can be added later if needed.